### PR TITLE
Fix Javadocs warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
                         <configuration>
                             <quiet>true</quiet>
                             <doclint>none</doclint>
-                            <failOnWarnings>false</failOnWarnings>
+                            <failOnWarnings>true</failOnWarnings>
                             <links>
                                 <link>https://javadoc.io/doc/com.vaadin/vaadin-platform-javadoc/${vaadin.version}</link>
                             </links>

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChart.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChart.java
@@ -257,9 +257,9 @@ public class OrgChart extends Div {
   }
 
   /**
-   * Adds a {@link DragAndDropListener} to the component.
+   * Adds a {@link DragAndDropEvent} listener to the component.
    *
-   * @param dragAndDropListener the listener to be added.
+   * @param listener the listener to be added.
    */
   public void addDragAndDropListener(ComponentEventListener<DragAndDropEvent> listener) {
     addListener(DragAndDropEvent.class, listener);


### PR DESCRIPTION
Close #81 & close #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new build profiles for Vaadin versions 23 and 24, allowing easier switching between different development environments.
  
- **Bug Fixes**
	- Updated documentation in the `OrgChart` class for clarity, ensuring accurate terminology for drag-and-drop events.

- **Chores**
	- Enhanced build process to enforce stricter documentation standards by failing the build on Javadoc warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->