### PR TITLE
fix: add json-digger dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -525,7 +525,7 @@
 		<profile>
 			<id>v24</id>
 			<properties>
-		        <vaadin.version>24.2.6</vaadin.version>
+		        <vaadin.version>24.3.20</vaadin.version>
         		<maven.compiler.source>17</maven.compiler.source>
 		        <maven.compiler.target>17</maven.compiler.target>
 		        <jetty.version>11.0.12</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,12 @@
 	                        <resourceBase>src/test/resources/META-INF/resources</resourceBase>
 	                    </resourceBases>
 	                </webAppConfig>
+	                <webApp>
+                        <resourceBases>
+	                        <resourceBase>src/main/resources/META-INF/resources</resourceBase>
+	                        <resourceBase>src/test/resources/META-INF/resources</resourceBase>
+	                    </resourceBases>
+	                </webApp>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChart.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChart.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 @Tag("fc-orgchart")
 @JsModule("./fc-orgchart.js")
 @CssImport("./fc-orgchart-styles.css")
+@NpmPackage(value = "json-digger", version = "2.0.2")
 public class OrgChart extends Div {
 
   private OrgChartItem orgChartItem;

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChart.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChart.java
@@ -1,17 +1,15 @@
-package com.flowingcode.vaadin.addons.orgchart;
-
 /*-
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +17,8 @@ package com.flowingcode.vaadin.addons.orgchart;
  * limitations under the License.
  * #L%
  */
+package com.flowingcode.vaadin.addons.orgchart;
+
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChartItem.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChartItem.java
@@ -1,17 +1,15 @@
-package com.flowingcode.vaadin.addons.orgchart;
-
 /*-
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +17,8 @@ package com.flowingcode.vaadin.addons.orgchart;
  * limitations under the License.
  * #L%
  */
+package com.flowingcode.vaadin.addons.orgchart;
+
 
 import java.io.Serializable;
 import java.util.ArrayList;

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/client/OrgChartState.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/client/OrgChartState.java
@@ -1,17 +1,15 @@
-package com.flowingcode.vaadin.addons.orgchart.client;
-
 /*-
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +17,8 @@ package com.flowingcode.vaadin.addons.orgchart.client;
  * limitations under the License.
  * #L%
  */
+package com.flowingcode.vaadin.addons.orgchart.client;
+
 
 import com.flowingcode.vaadin.addons.orgchart.client.constants.ChartConstants;
 import com.flowingcode.vaadin.addons.orgchart.client.enums.ChartDirectionEnum;

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/client/constants/ChartConstants.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/client/constants/ChartConstants.java
@@ -1,17 +1,15 @@
-package com.flowingcode.vaadin.addons.orgchart.client.constants;
-
 /*-
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +17,8 @@ package com.flowingcode.vaadin.addons.orgchart.client.constants;
  * limitations under the License.
  * #L%
  */
+package com.flowingcode.vaadin.addons.orgchart.client.constants;
+
 
 public interface ChartConstants {
 

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/client/enums/ChartDirectionEnum.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/client/enums/ChartDirectionEnum.java
@@ -1,17 +1,15 @@
-package com.flowingcode.vaadin.addons.orgchart.client.enums;
-
 /*-
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +17,8 @@ package com.flowingcode.vaadin.addons.orgchart.client.enums;
  * limitations under the License.
  * #L%
  */
+package com.flowingcode.vaadin.addons.orgchart.client.enums;
+
 
 /**
  * Enumeration of the directions that the organization chart can have. <br>

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/extra/TemplateLiteralRewriter.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/extra/TemplateLiteralRewriter.java
@@ -2,14 +2,14 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package com.flowingcode.vaadin.addons.orgchart.extra;
 
 /**

--- a/src/main/resources/META-INF/frontend/fc-orgchart.js
+++ b/src/main/resources/META-INF/frontend/fc-orgchart.js
@@ -20,6 +20,7 @@
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 import jQuery from "jquery";
 import html2canvas from 'html2canvas';
+import JSONDigger from "json-digger/dist/json-digger.js";
 
 /**
  * `fc-orgchart`
@@ -93,6 +94,7 @@ class FCOrgChart extends PolymerElement {
         });  
         
         window.html2canvas = html2canvas;
+        window.JSONDigger  = JSONDigger;
 
         // add title
         var title = state.chartTitle;

--- a/src/main/resources/META-INF/frontend/fc-orgchart.js
+++ b/src/main/resources/META-INF/frontend/fc-orgchart.js
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 import jQuery from "jquery";
 import html2canvas from 'html2canvas';

--- a/src/main/resources/META-INF/resources/frontend/fc-orgchart-styles.css
+++ b/src/main/resources/META-INF/resources/frontend/fc-orgchart-styles.css
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
  
 .orgchart .node {
 	width: 140px;

--- a/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
@@ -2,14 +2,14 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package com.flowingcode.vaadin.addons;
 
 import com.vaadin.flow.component.html.Div;

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/BottomTopDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/BottomTopDemo.java
@@ -2,14 +2,14 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package com.flowingcode.vaadin.addons.orgchart;
 
 import java.util.Arrays;

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/DemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/DemoView.java
@@ -2,14 +2,14 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package com.flowingcode.vaadin.addons.orgchart;
 
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/DragAndDropExportDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/DragAndDropExportDemo.java
@@ -2,14 +2,14 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package com.flowingcode.vaadin.addons.orgchart;
 
 import java.util.Arrays;

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/HybridEnhancedChartDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/HybridEnhancedChartDemo.java
@@ -2,14 +2,14 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package com.flowingcode.vaadin.addons.orgchart;
 
 import java.util.Arrays;

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/ImageInTitleDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/ImageInTitleDemo.java
@@ -2,14 +2,14 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package com.flowingcode.vaadin.addons.orgchart;
 
 import java.util.Arrays;

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/OrgchartDemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/OrgchartDemoView.java
@@ -2,14 +2,14 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package com.flowingcode.vaadin.addons.orgchart;
 
 import com.flowingcode.vaadin.addons.DemoLayout;

--- a/src/test/resources/META-INF/resources/frontend/styles/orgchart/demo-styles.css
+++ b/src/test/resources/META-INF/resources/frontend/styles/orgchart/demo-styles.css
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 
 .chart-container {
   position: relative;

--- a/src/test/resources/META-INF/resources/frontend/styles/orgchart/hybrid-demo-styles.css
+++ b/src/test/resources/META-INF/resources/frontend/styles/orgchart/hybrid-demo-styles.css
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2023 Flowing Code S.A.
+ * Copyright (C) 2017 - 2025 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 .hybrid-chart .orgchart .node {
 	width: 220px;
 }


### PR DESCRIPTION
I had to upgrade Vaadin 24 to 24.3 because 23.2 failed with
> SyntaxError: Unexpected token (3246:11334) in J:/fc/addons/OrgChartAddon/node_modules/json-digger/dist/json-digger.js


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded our UI framework to the latest stable release (Vaadin version 24.3.20) to enhance overall performance and reliability.

- **New Features**
  - Integrated a third-party JSON processing utility (`json-digger` version 2.0.2) that is now available globally.
  - Enhanced the organizational chart component, delivering more robust data handling and a dynamic user experience.
  - These improvements lay the groundwork for smoother interactions and future scalability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->