### PR TITLE
docs: fix param name in javadoc

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChart.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChart.java
@@ -466,7 +466,7 @@ public class OrgChart extends Div {
    * Fires a siblings added event.
    *
    * @param item the node that received new siblings
-   * @param newSibling list of the newly added siblings
+   * @param newSiblings list of the newly added siblings
    * @param fromClient whether the event originated from the client side
    */
   protected void fireSiblingsAddedEvent(OrgChartItem item, List<OrgChartItem> newSiblings,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Javadoc parameter name in an event-related method to match the actual parameter, improving accuracy and clarity for developers referencing the API docs. No functional changes.
* **Chores**
  * Minor cleanup to ensure documentation consistency across the codebase. No impact on runtime behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->