### PR TITLE
build(demo): add demo dependency with vaadin-confirm-dialog-flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,11 @@
 			<version>3.10.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-confirm-dialog-flow</artifactId>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
`EditChartDemo` uses `ConfirmDialog` (which was a transitive dependency of commons-demo 3.7.0 and earlier https://github.com/FlowingCode/CommonsDemo/pull/38)

https://github.com/FlowingCode/OrgChartAddon/blob/669f9889e4e86ad52bfa71f10ebdded0442d273f/src/test/java/com/flowingcode/vaadin/addons/orgchart/EditChartDemo.java#L381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test dependencies to support enhanced testing capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->