### PR TITLE
Vaadin 25 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -543,7 +543,7 @@
 			<properties>
 				<maven.compiler.source>21</maven.compiler.source>
 				<maven.compiler.target>21</maven.compiler.target>
-				<vaadin.version>25.0.0-beta2</vaadin.version>
+				<vaadin.version>25.0.3</vaadin.version>
 				<jetty.version>11.0.26</jetty.version>
 			</properties>
 			<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,17 @@
             </exclusions>
         </dependency>
         <dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+			<version>1.18.34</version>
+		</dependency>
+        <dependency>
+            <groupId>com.flowingcode.vaadin</groupId>
+            <artifactId>json-migration-helper</artifactId>
+            <version>0.9.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -547,6 +547,11 @@
 				<jetty.version>11.0.26</jetty.version>
 			</properties>
 			<dependencies>
+                <dependency>
+					<groupId>com.vaadin</groupId>
+					<artifactId>vaadin-dev</artifactId>
+					<optional>true</optional>
+				</dependency>
 				<dependency>
 					<groupId>com.flowingcode.vaadin.addons.demo</groupId>
 					<artifactId>commons-demo</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -555,7 +555,7 @@
 				<dependency>
 					<groupId>com.flowingcode.vaadin.addons.demo</groupId>
 					<artifactId>commons-demo</artifactId>
-					<version>5.0.0</version>
+					<version>5.1.0</version>
 					<scope>test</scope>
 				</dependency>
 			</dependencies>

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChart.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChart.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChart.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChart.java
@@ -28,6 +28,7 @@ import com.flowingcode.vaadin.addons.orgchart.event.NodeUpdatedEvent;
 import com.flowingcode.vaadin.addons.orgchart.event.NodesRemovedEvent;
 import com.flowingcode.vaadin.addons.orgchart.event.ParentAddedEvent;
 import com.flowingcode.vaadin.addons.orgchart.event.SiblingsAddedEvent;
+import com.flowingcode.vaadin.jsonmigration.JsonMigration;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.ComponentEvent;
@@ -44,6 +45,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import lombok.experimental.ExtensionMethod;
 
 /**
  * OrgChart component definition. <br>
@@ -57,6 +59,7 @@ import java.util.stream.Collectors;
 @NpmPackage(value = "orgchart", version = "3.7.0")
 @NpmPackage(value = "html2canvas", version = "1.4.1")
 @NpmPackage(value = "jquery", version = "3.6.2")
+@NpmPackage(value = "@polymer/polymer", version = "3.5.2")
 @JsModule("jquery/dist/jquery.js")
 @JsModule("orgchart/dist/js/jquery.orgchart.js")
 @CssImport("orgchart/dist/css/jquery.orgchart.min.css")
@@ -64,6 +67,7 @@ import java.util.stream.Collectors;
 @JsModule("./fc-orgchart.js")
 @CssImport("./fc-orgchart-styles.css")
 @NpmPackage(value = "json-digger", version = "2.0.2")
+@ExtensionMethod(value = JsonMigration.class, suppressBaseMethods = true)
 public class OrgChart extends Div {
 
   private OrgChartItem orgChartItem;

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChartItem.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/OrgChartItem.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/client/OrgChartState.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/client/OrgChartState.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/client/constants/ChartConstants.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/client/constants/ChartConstants.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/client/enums/ChartDirectionEnum.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/client/enums/ChartDirectionEnum.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/event/ChildrenAddedEvent.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/event/ChildrenAddedEvent.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/event/NodeUpdatedEvent.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/event/NodeUpdatedEvent.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * OrgChart Add-on
+ * %%
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.flowingcode.vaadin.addons.orgchart.event;
 
 import com.flowingcode.vaadin.addons.orgchart.OrgChart;

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/event/NodesRemovedEvent.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/event/NodesRemovedEvent.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/event/ParentAddedEvent.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/event/ParentAddedEvent.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/event/SiblingsAddedEvent.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/event/SiblingsAddedEvent.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/orgchart/extra/TemplateLiteralRewriter.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/orgchart/extra/TemplateLiteralRewriter.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/frontend/fc-orgchart.js
+++ b/src/main/resources/META-INF/frontend/fc-orgchart.js
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/resources/frontend/fc-orgchart-styles.css
+++ b/src/main/resources/META-INF/resources/frontend/fc-orgchart-styles.css
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/BottomTopDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/BottomTopDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/DemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/DemoView.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/DragAndDropExportDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/DragAndDropExportDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/EditChartDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/EditChartDemo.java
@@ -177,7 +177,7 @@ public class EditChartDemo extends VerticalLayout {
     // Action Selector
     actionSelector = new RadioButtonGroup<>();
     actionSelector.setLabel("Select Action");
-    actionSelector.setItems("Add", "Edit", "Delete");
+    ReflectionUtil.setItems(actionSelector,"Add", "Edit", "Delete");
     actionSelector.addValueChangeListener(event -> updateComponentStates());
 
     Div separator = new Div();
@@ -204,7 +204,7 @@ public class EditChartDemo extends VerticalLayout {
     // Relation type selector
     typeSelector = new RadioButtonGroup<String>();
     typeSelector.setLabel("Select Relation Type:");
-    typeSelector.setItems("Parent(root)", "Child", "Sibling");
+    ReflectionUtil.setItems(typeSelector, "Parent(root)", "Child", "Sibling");
     typeSelector.setValue("Child");
     typeSelector.addThemeVariants(RadioGroupVariant.LUMO_VERTICAL);
 

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/EditChartDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/EditChartDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/EditChartDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/EditChartDemo.java
@@ -177,7 +177,10 @@ public class EditChartDemo extends VerticalLayout {
     // Action Selector
     actionSelector = new RadioButtonGroup<>();
     actionSelector.setLabel("Select Action");
+    // #if vaadin eq 0
     ReflectionUtil.setItems(actionSelector,"Add", "Edit", "Delete");
+    // #endif
+    // show-source actionSelector.setItems("Add", "Edit", "Delete");
     actionSelector.addValueChangeListener(event -> updateComponentStates());
 
     Div separator = new Div();
@@ -204,7 +207,10 @@ public class EditChartDemo extends VerticalLayout {
     // Relation type selector
     typeSelector = new RadioButtonGroup<String>();
     typeSelector.setLabel("Select Relation Type:");
+    // #if vaadin eq 0
     ReflectionUtil.setItems(typeSelector, "Parent(root)", "Child", "Sibling");
+     // #endif
+    // show-source typeSelector.setItems("Parent(root)", "Child", "Sibling");
     typeSelector.setValue("Child");
     typeSelector.addThemeVariants(RadioGroupVariant.LUMO_VERTICAL);
 

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/HybridDataPropertyDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/HybridDataPropertyDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/HybridEnhancedChartDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/HybridEnhancedChartDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/ImageInTitleDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/ImageInTitleDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/OrgchartDemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/OrgchartDemoView.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/ReflectionUtil.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/ReflectionUtil.java
@@ -1,0 +1,41 @@
+/*-
+ * #%L
+ * OrgChart Add-on
+ * %%
+ * Copyright (C) 2017 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.orgchart;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
+
+public class ReflectionUtil {
+
+  /** Reflective call in order to mantain binary compatibility with Vaadin 14 - 24+ */
+  static void setItems(RadioButtonGroup<String> radioButtonGroup,
+      String... items) {
+    try {
+      RadioButtonGroup.class
+          .getMethod("setItems", Collection.class)
+          .invoke(radioButtonGroup, Arrays.asList(items));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/orgchart/ReflectionUtil.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/orgchart/ReflectionUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2026 Flowing Code
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 
 public class ReflectionUtil {
 
-  /** Reflective call in order to mantain binary compatibility with Vaadin 14 - 24+ */
+  /** Reflective call in order to maintain binary compatibility with Vaadin 14 - 24+ */
   static void setItems(RadioButtonGroup<String> radioButtonGroup,
       String... items) {
     try {

--- a/src/test/resources/META-INF/resources/frontend/styles/orgchart/demo-styles.css
+++ b/src/test/resources/META-INF/resources/frontend/styles/orgchart/demo-styles.css
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/META-INF/resources/frontend/styles/orgchart/edit-chart-demo-styles.css
+++ b/src/test/resources/META-INF/resources/frontend/styles/orgchart/edit-chart-demo-styles.css
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/META-INF/resources/frontend/styles/orgchart/hybrid-demo-styles.css
+++ b/src/test/resources/META-INF/resources/frontend/styles/orgchart/hybrid-demo-styles.css
@@ -2,7 +2,7 @@
  * #%L
  * OrgChart Add-on
  * %%
- * Copyright (C) 2017 - 2025 Flowing Code S.A.
+ * Copyright (C) 2017 - 2026 Flowing Code S.A.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Vaadin upgraded to 25.0.3; commons-demo bumped to 5.1.0.
  * Added Lombok (provided), json-migration-helper, and an optional vaadin-dev dependency.
  * Added a Polymer frontend package for improved integration.

* **Chores**
  * Updated copyright years across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->